### PR TITLE
iOS13 미지원 모듈 제거 (GPS)

### DIFF
--- a/Plogging/GPS/PathManager.swift
+++ b/Plogging/GPS/PathManager.swift
@@ -31,9 +31,7 @@ class PathManager: NSObject {
 
     // todo 위치 연결 팝업 연결
     func isSetPermissions() {
-        if locationManager.authorizationStatus.rawValue < CLAuthorizationStatus.authorizedAlways.rawValue {
-            locationManager.requestWhenInUseAuthorization()
-        }
+        locationManager.requestWhenInUseAuthorization()
     }
     
     func setupMapview(on mapView: MKMapView) {


### PR DESCRIPTION
타겟 버전 iOS 13으로 내릴 시 문제되는 모듈 제거 (위치 권한 확인 쪽)